### PR TITLE
Add model-based pop detection

### DIFF
--- a/src/tennis_cut/README.md
+++ b/src/tennis_cut/README.md
@@ -1,11 +1,13 @@
 # Tennis Cut CLI
 
-Command-line tool for extracting tennis swing clips from a video. For now it relies solely on audio peak detection and does not crop the video.
+Command-line tool for extracting tennis swing clips from a video. It relies on a
+trained audio "pop" model to locate impact moments. The model is produced by
+`train_audio_pop.py` and exported via fastai's `Learner.export`.
 
 Run:
 
 ```bash
-python tennis_cut.py <input.mp4> [options]
+python tennis_cut.py <input.mp4> --model path/to/audio_pop.pth [options]
 ```
 
 The available options match those described in `spec.md` under the *Command-line Interface* section.


### PR DESCRIPTION
## Summary
- use CNN from `train_audio_pop.py` for detecting impacts
- require `--model` argument to supply trained weights
- document new argument in README
- load trained model via fastai `load_learner`

## Testing
- `ruff check .`
- `python -m py_compile src/tennis_cut/tennis_cut.py`


------
https://chatgpt.com/codex/tasks/task_e_685aaea12c288322be1d95e0a5b4bb02