### PR TITLE
Add timestamps to tennis_cut logging

### DIFF
--- a/src/tennis_cut/tennis_cut.py
+++ b/src/tennis_cut/tennis_cut.py
@@ -162,7 +162,11 @@ def setup_logging(args: argparse.Namespace) -> None:
         level = logging.INFO
     if args.quiet:
         level = logging.ERROR
-    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s %(levelname)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
 
 def check_ffmpeg() -> None:


### PR DESCRIPTION
## Summary
- show timestamps in tennis_cut log output

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_685ce378065083229338b18bd76df9a8