### PR TITLE
Add shot type annotation

### DIFF
--- a/examples/videos/tester.json
+++ b/examples/videos/tester.json
@@ -7,5 +7,12 @@
     15.087,
     18.463
   ],
+  "shots": [
+    {"time": 4.354, "type": "forehand"},
+    {"time": 8.224, "type": "backhand"},
+    {"time": 11.541, "type": "volley"},
+    {"time": 15.087, "type": "forehand"},
+    {"time": 18.463, "type": "serve"}
+  ],
   "done": true
 }


### PR DESCRIPTION
## Summary
- add shot type keys to annotation GUI
- save `shots` objects in the JSON output
- provide example JSON with shot type data

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_687497981d448322b3c06a0053026aac